### PR TITLE
Fix author lists in BibTeX format

### DIFF
--- a/ECDL2004.bib
+++ b/ECDL2004.bib
@@ -1,5 +1,5 @@
 @inproceedings{ECDLS1Eslau2004,
-  author       = {Anna Eslau, H. Lundbeck and Marianne Lykke Nielsen},
+  author       = {Anna Eslau and H. Lundbeck and Marianne Lykke Nielsen},
   title        = {Introduction to user centred approaches to KOS},
   year    = {2004},
   venue        = {European Conference on Digital Libraries},
@@ -18,7 +18,7 @@
 }
 
 @inproceedings{ECDLS1RasmussenMarianneNielsen2004,
-  author       = {Hella Moller Rasmussen, H. Lundbeck and Marianne Lykke Nielsen},
+  author       = {Hella Moller Rasmussen and H. Lundbeck and Marianne Lykke Nielsen},
   title        = {Developing a tool for searching and learning - the potential of an enriched end user thesaurus},
   year = {2004},
   venue        = {European Conference on Digital Libraries},
@@ -36,7 +36,7 @@
 }
 
 @inproceedings{ECDLS1Weaver2004,
-  author       = {Mathew Weaver, Timothy Tolle, Marianne Lykke Nielsen, and Lois Delcambre},
+  author       = {Mathew Weaver and Timothy Tolle and Marianne Lykke Nielsen and and Lois Delcambre},
   title        = {Knowledge Structures for a Domain-Specific Digital Library for Natural Resource Managers},
   year = {2004},
   venue        = {European Conference on Digital Libraries},
@@ -72,7 +72,7 @@
 }
 
 @inproceedings{ECDLS2Miles2004,
-  author       = {Alistair Miles, Brian Matthews, Nikki Rogers, and Dave Beckett},
+  author       = {Alistair Miles and Brian Matthews and Nikki Rogers and and Dave Beckett},
   title        = {SKOS: Standards and Best Practices for USING Knowledge Organisation Systems ON THE Semantic Web},
   year = {2004},
   venue        = {European Conference on Digital Libraries},
@@ -108,7 +108,7 @@
 }
 
 @inproceedings{ECDLS3Gawrysiak2004,
-  author       = {Piotr Gawrysiak, Henryk Rybinski, and Michal Okoniewski},
+  author       = {Piotr Gawrysiak and Henryk Rybinski and and Michal Okoniewski},
   title        = {Dynamic KOS building & management for library information systems},
   year = {2004},
   venue        = {European Conference on Digital Libraries},

--- a/ECDL2005.bib
+++ b/ECDL2005.bib
@@ -17,7 +17,7 @@
 }
 
 @inproceedings{ECDLNielsen2005,
-  author       = {Marianne Lykke Nielsen, Mathew J. Weaver, Lois Delcambre, and Timothy Tolle},
+  author       = {Marianne Lykke Nielsen and Mathew J. Weaver and Lois Delcambre and and Timothy Tolle},
   title        = {Enhancing domain-specific digital library with facilities for vocabulary exploration},
   year = {2005},
   venue        = {European Conference on Digital Libraries},
@@ -34,7 +34,7 @@
  }
 
 @inproceedings{ECDLAlistairMiles2005,
-  author       = {Alistair Miles, Brian Mattews, Michael Wilson and Dan Brickley},
+  author       = {Alistair Miles and Brian Mattews and Michael Wilson and Dan Brickley},
   title        = {NKOS issues in W3C's Simple Knowledge Organisation System (SKOS)},
   year = {2005},
   venue        = {European Conference on Digital Libraries},
@@ -61,7 +61,7 @@
 }
 
 @inproceedings{ECDLPeterScheir2005,
-  author       = {Peter Scheir, Stefanie Lindstaedt and Mathias Lux},
+  author       = {Peter Scheir and Stefanie Lindstaedt and Mathias Lux},
   title        = {Associative retrieval over different knowledge organization systems},
   year = {2005},
   venue        = {European Conference on Digital Libraries},
@@ -79,7 +79,7 @@
 }
 
 @inproceedings{ECDLEdwardAFox2005,
-  author       = {Edward Fox, Baoping Zhang and Ryan Richardson},
+  author       = {Edward Fox and Baoping Zhang and Ryan Richardson},
   title        = {Networked knowledge organization for the networked digital library of theses and dissertations},
   year = {2005},
   venue        = {European Conference on Digital Libraries},
@@ -97,7 +97,7 @@
 }
 
 @inproceedings{ECDLFalquet2005,
-  author       = {Gilles Falquet, Luka Nerima, Claire-Lise Mottaz Jiang and Jean-Claude Ziswiler},
+  author       = {Gilles Falquet and Luka Nerima and Claire-Lise Mottaz Jiang and Jean-Claude Ziswiler},
   title        = {Building virtual documents by integrating hyperbooks},
   year = {2005},
   venue        = {European Conference on Digital Libraries},

--- a/ECDL2007.bib
+++ b/ECDL2007.bib
@@ -1,5 +1,5 @@
 @inproceedings{ECDLTonkin2007,
-  author       = {Emma Tonkin, Ana Alice Baptista, Seth van Hooland, Andrea Resmini, Eva Mendéz and Liddy Neville},
+  author       = {Emma Tonkin and Ana Alice Baptista and Seth van Hooland and Andrea Resmini and Eva Mendéz and Liddy Neville},
   title        = {Kinds of Tags: a collaborative research study on tag usage and structure},
   year    = {2007},
   venue        = {European Conference on Digital Libraries},
@@ -18,7 +18,7 @@
 }
 
 @inproceedings{ECDLHeckner2007,
-  author       = {Markus Heckner, Susanne Mühlbacher, Christian Wolff},
+  author       = {Markus Heckner and Susanne Mühlbacher and Christian Wolff},
   title        = {Tagging tagging. A classification model for user keywords in scientific bibliography management systems},
   year = {2007},
   venue        = {European Conference on Digital Libraries},
@@ -108,7 +108,7 @@
 }
 
 @inproceedings{ECDLMayr2007,
-  author       = {Philipp Mayr, Vivien Petras, Anne-Kathrin Walter},
+  author       = {Philipp Mayr and Vivien Petras and Anne-Kathrin Walter},
   title        = {Results from a German terminology mapping effort: intra- and interdisciplinary cross-concordances between controlled vocabularies},
   year = {2007},
   venue        = {European Conference on Digital Libraries},
@@ -126,7 +126,7 @@
 }
 
 @inproceedings{ECDLKaczmarek2007,
-  author       = {Mateusz Kaczmarek, Sebastian Ryszard Kruk, and Adam Gzella},
+  author       = {Mateusz Kaczmarek and Sebastian Ryszard Kruk and and Adam Gzella},
   title        = {Collaborative Building of Controlled Vocabulary Crosswalks},
   year = {2007},
   venue        = {European Conference on Digital Libraries},

--- a/ECDL2008.bib
+++ b/ECDL2008.bib
@@ -90,7 +90,7 @@
 }
 
 @inproceedings{ECDLNielsen2008,
-  author       = {Marianne Lykke Nielsen, Susan Price and Lois Delcambre},
+  author       = {Marianne Lykke Nielsen and Susan Price and Lois Delcambre},
   title        = {Indexing with semantic components improve information retrieval in domain-specific web portal},
   year = {2008},
   venue        = {European Conference on Digital Libraries},

--- a/ECDL2009.bib
+++ b/ECDL2009.bib
@@ -45,7 +45,7 @@
 }
 
 @inproceedings{ECDLMurthy2009,
-  author       = {Uma Murthy, Edward Fox, Naren Ramakrishnan, Andrea Kavanaugh, Steve Sheetz, Donald Shoemaker and Venkataraghavan Srinivasan},
+  author       = {Uma Murthy and Edward Fox and Naren Ramakrishnan and Andrea Kavanaugh and Steve Sheetz and Donald Shoemaker and Venkataraghavan Srinivasan},
   title        = {Building an ontology for crisis, tragedy and recovery},
   year = {2009},
   venue        = {European Conference on Digital Libraries},
@@ -54,7 +54,7 @@
 }
 
 @inproceedings{ECDLGolub2009,
-  author       = {Koraljka Golub, Vanda Broughton, George Buchanan, Emlyn Everitt, Marianne Lykke Nielsen, Dagobert Soergel and Douglas Tudhope},
+  author       = {Koraljka Golub and Vanda Broughton and George Buchanan and Emlyn Everitt and Marianne Lykke Nielsen and Dagobert Soergel and Douglas Tudhope},
   title        = {EASTER project: Evaluating Automated Subject Tools for Enhancing Retrieval},
   year = {2009},
   venue        = {European Conference on Digital Libraries},
@@ -81,7 +81,7 @@
 }
 
 @inproceedings{ECDLPriest2009,
-  author       = {Andy Priest, Janine Rigby, Caroline Williams, Ceri Binding and Douglas Tudhope},
+  author       = {Andy Priest and Janine Rigby and Caroline Williams and Ceri Binding and Douglas Tudhope},
   title        = {The PERsonalisation TAgging interface INformation in Services, PERTAINS project: presenting tag recommenders in UK national services},
   year = {2009},
   venue        = {European Conference on Digital Libraries},
@@ -90,7 +90,7 @@
 }
 
 @inproceedings{ECDLMayr2009,
-  author       = {Philipp Mayr, Philipp Schaer and York Sure},
+  author       = {Philipp Mayr and Philipp Schaer and York Sure},
   title        = {Intra- and interdisciplinary cross-concordance for information retrieval},
   year = {2009},
   venue        = {European Conference on Digital Libraries},

--- a/ECDL2010.bib
+++ b/ECDL2010.bib
@@ -27,7 +27,7 @@
 }
 
 @inproceedings{ECDLMayr2010,
-  author       = {Philipp Mayr, Peter Mutschke, Philipp Schaer, and York Sure},
+  author       = {Philipp Mayr and Peter Mutschke and Philipp Schaer and and York Sure},
   title        = {Search term recommendation and non-textual ranking evaluated},
   year = {2010},
   venue        = {European Conference on Digital Libraries},
@@ -45,7 +45,7 @@
 }
 
 @inproceedings{ECDLSpiteri2010,
-  author       = {Louise Spiteri, Laurel Tarulli, Alyssa Graybeal},
+  author       = {Louise Spiteri and Laurel Tarulli and Alyssa Graybeal},
   title        = {The public library catalogue as a social space: Transaction log analysis of user interaction with social discovery systems},
   year = {2010},
   venue        = {European Conference on Digital Libraries},
@@ -54,7 +54,7 @@
 }
 
 @inproceedings{ECDLManguinhas2010,
-  author       = {Hugo Manguinhas, Jos{\'e} Borbinha},
+  author       = {Hugo Manguinhas and Jos{\'e} Borbinha},
   title        = {Integrating Knowledge Organization Systems Registries with Metadata Registries},
   year = {2010},
   venue        = {European Conference on Digital Libraries},
@@ -72,7 +72,7 @@
 }
 
 @inproceedings{ECDLHercher2010,
-  author       = {Johannes Hercher, Harald Sack},
+  author       = {Johannes Hercher and Harald Sack},
   title        = {Indexing Audiovisual Heritage in Germany by SKOSification of Existing Vocabularies},
   year = {2010},
   venue        = {European Conference on Digital Libraries},
@@ -81,7 +81,7 @@
 }
 
 @inproceedings{ECDLBinding2010,
-  author       = {Ceri Binding, Doug Tudhope},
+  author       = {Ceri Binding and Doug Tudhope},
   title        = {KOS-based tools for archaeological dataset interoperability},
   year = {2010},
   venue        = {European Conference on Digital Libraries},
@@ -90,7 +90,7 @@
 }
 
 @inproceedings{ECDLAlbertoni2010,
-  author       = {Riccardo Albertoni, Monica De Martino, Franca Giannini},
+  author       = {Riccardo Albertoni and Monica De Martino and Franca Giannini},
   title        = {SKOS and semantic web best practice to access terminological resources: NatureSDIPlus and CHRONIOUS hands-on experience},
   year = {2010},
   venue        = {European Conference on Digital Libraries},
@@ -99,7 +99,7 @@
 }
 
 @inproceedings{ECDLSchandl2010,
-  author       = {Thomas Schandl, Andreas Blumauer, Helmut Nagy},
+  author       = {Thomas Schandl and Andreas Blumauer and Helmut Nagy},
   title        = {Using Linked Data in Thesaurus Management},
   year = {2010},
   venue        = {European Conference on Digital Libraries},

--- a/TPDL2011.bib
+++ b/TPDL2011.bib
@@ -1,6 +1,6 @@
 @inproceedings{TPDLStellatoMorshedJohannsen2011,
   title       = {A Collaborative Framework for Managing and Publishing KOS},
-  author      = {Armando Stellato, Ahsan Morshed, Gudrun Johannsen, Yves Jacques, Caterina Caracciolo, Sachit Rajbhandari, Imma Subirats, Johannes Keizer},
+  author      = {Armando Stellato and Ahsan Morshed and Gudrun Johannsen and Yves Jacques and Caterina Caracciolo and Sachit Rajbhandari and Imma Subirats and Johannes Keizer},
   year    = {2011},
   venue        = {Theory and Practice of Digital Libraries},
   location     = {Berlin, Germany},
@@ -9,7 +9,7 @@
 
 @inproceedings{TPDLMader2011,
   title       = {Quality Criteria for Controlled Web Vocabularies},
-  author        = {Christian Mader, Bernhard Haslhofer},
+  author        = {Christian Mader and Bernhard Haslhofer},
   year    = {2011},
   venue        = {Theory and Practice of Digital Libraries},
   location     = {Berlin, Germany},
@@ -17,7 +17,7 @@
 }
 
 @inproceedings{TPDLMorshed2011,
-  author       = {Ahsan Morshed, Benjamin Zapilko, Gudrun Johannsen, Philipp Mayr, Johannes Keizer},
+  author       = {Ahsan Morshed and Benjamin Zapilko and Gudrun Johannsen and Philipp Mayr and Johannes Keizer},
   title        = {Evaluating approaches to automatically match thesauri from different domains for Linked Open Data},
   year    = {2011},
   venue        = {Theory and Practice of Digital Libraries},
@@ -53,7 +53,7 @@
 }
 
 @inproceedings{TPDLIsaac2011,
-  author       = {Antoine Isaac, Jacco van Ossenbruggen,  Victor de Boer, Jan Wielemaker, Guus Schreiber},
+  author       = {Antoine Isaac and Jacco van Ossenbruggen and  Victor de Boer and Jan Wielemaker and Guus Schreiber},
   title        = {Europeana and semantic alignment of vocabularies},
   year    = {2011},
   venue        = {Theory and Practice of Digital Libraries},
@@ -71,7 +71,7 @@
 }
 
 @inproceedings{TPDLHoek2011,
-  author       = {Wilko van Hoek, Brigitte Mathiak, Philipp Mayr, Sascha Schüller},
+  author       = {Wilko van Hoek and Brigitte Mathiak and Philipp Mayr and Sascha Schüller},
   title        = {Comparing the accuracy of the semantic similarity provided by the Normalized Google Distance (NGD) and the Search Term Recommender (STR)},
   year    = {2011},
   venue        = {Theory and Practice of Digital Libraries},
@@ -89,7 +89,7 @@
 }
 
 @inproceedings{TPDLDextreClarke2011,
-  author       = {Stella Dextre Clarke, Johan De Smedt},
+  author       = {Stella Dextre Clarke and Johan De Smedt},
   title        = {ISO 25964-1: a new standard for development of thesauri and exchange of thesaurus data},
   year    = {2011},
   venue        = {Theory and Practice of Digital Libraries},

--- a/TPDL2012.bib
+++ b/TPDL2012.bib
@@ -1,5 +1,5 @@
 @inproceedings{Lin2012,
-  author       = {Xia Lin, Dagobert Soergel and Murtha Baca},
+  author       = {Xia Lin and Dagobert Soergel and Murtha Baca},
   title        = {Meaningful Concept Displays: The First Step},
   year    = {2012},
   venue        = {Theory and Practice of Digital Libraries)},
@@ -44,7 +44,7 @@
 }
 
 @inproceedings{Khoo2012,
-  author       = {Michael Khoo, Douglas Tudhope and Ceri Binding},
+  author       = {Michael Khoo and Douglas Tudhope and Ceri Binding},
   title        = {Extracting Dewey Decimal Classifications from Dublin Core Metadata Records With the DISTIL Project: Preliminary Findings and Observations},
   year    = {2012},
   venue        = {Theory and Practice of Digital Libraries)},
@@ -52,8 +52,8 @@
   url= {https://at-web1.comp.glam.ac.uk/pages/research/hypermedia/nkos/nkos2012/abstracts/Khoo.pdf}
 }
 
-@inproceedings{L\"uke2012,
-  author       = {Thomas Lüke, Wilko van Hoek, Philipp Schaer, Philipp Mayr},
+@inproceedings{Lueke2012,
+  author       = {Thomas Lüke and Wilko van Hoek and Philipp Schaer and Philipp Mayr},
   title        = {Creation of custom KOS-based recommendation systems},
   year    = {2012},
   venue        = {Theory and Practice of Digital Libraries)},
@@ -71,7 +71,7 @@
 }
 
 @inproceedings{Mateos2012,
-  author       = {David Rodríguez Mateos, Gema Bueno de la Fuente, Jane Greenberg, Liliana Melgar, Nancy Gómez, Craig Willis, Eva Méndez, Joan Boone},
+  author       = {David Rodríguez Mateos and Gema Bueno de la Fuente and Jane Greenberg and Liliana Melgar and Nancy Gómez and Craig Willis and Eva Méndez and Joan Boone},
   title        = {Demonstrating HIVE and HIVE-ES: Supporting Term Browsing and Automatic Text Indexing with Linked Open Vocabularies},
   year    = {2012},
   venue        = {Theory and Practice of Digital Libraries)},

--- a/TPDL2013.bib
+++ b/TPDL2013.bib
@@ -1,5 +1,5 @@
 @inproceedings{TPDLBuzydlowski2013,
-  author       = {Jan Buzydlowski, Lillian Cassel, Xia Lin},
+  author       = {Jan Buzydlowski and Lillian Cassel and Xia Lin},
   title        = {Visualization of Candidate Terms for Classification of Papers},
   year    = {2013},
   venue        = {Theory and Practice of Digital Libraries},
@@ -7,7 +7,7 @@
   url = {https://at-web1.comp.glam.ac.uk/pages/research/hypermedia/nkos/nkos2013/content/NKOS2013_buzydlowski.pdf}
 }
 @inproceedings{TPDLBinding2013,
-  author       = {Ceri Binding, Douglas Tudhope, Jae-wook Ahn, Michael Khoo, Xia Lin, Diana Massam, Hilary Jones},
+  author       = {Ceri Binding and Douglas Tudhope and Jae-wook Ahn and Michael Khoo and Xia Lin and Diana Massam and Hilary Jones},
   title        = {Digging into Metadata},
   year    = {2013},
   venue        = {Theory and Practice of Digital Libraries},
@@ -15,7 +15,7 @@
   url = {https://at-web1.comp.glam.ac.uk/pages/research/hypermedia/nkos/nkos2013/content/NKOS2013_khoo.pdf}
 }
 @inproceedings{TPDLWhite2013,
-  author       = {Howard D. White, Philipp Mayr},
+  author       = {Howard D. White and Philipp Mayr},
   title        = {Pennants for Descriptors},
   year    = {2013},
   venue        = {Theory and Practice of Digital Libraries},
@@ -23,7 +23,7 @@
   url = {https://at-web1.comp.glam.ac.uk/pages/research/hypermedia/nkos/nkos2013/content/NKOS2013_white_mayr.pdf}
 }
 @inproceedings{TPDLIndarto2013,
-  author       = {Eko Indarto, Andrea Scharnhorst, Marat Charlaganov},
+  author       = {Eko Indarto and Andrea Scharnhorst and Marat Charlaganov},
   title        = {An Extensible Recommendation System to support Trusted Digital Repositories},
   year    = {2013},
   venue        = {Theory and Practice of Digital Libraries},
@@ -31,7 +31,7 @@
   url = {https://at-web1.comp.glam.ac.uk/pages/research/hypermedia/nkos/nkos2013/content/NKOS2013_indarto.pdf}
 }
 @inproceedings{TPDLMayr2013,
-  author       = {Philipp Mayr, Thomas Lüke, Philipp Schaer},
+  author       = {Philipp Mayr and Thomas Lüke and Philipp Schaer},
   title        = {Demonstrating a Framework for KOS-based Recommendations Systems},
   year    = {2013},
   venue        = {Theory and Practice of Digital Libraries},

--- a/TPDL2014.bib
+++ b/TPDL2014.bib
@@ -1,5 +1,5 @@
 @inproceedings{TPDLSmedt2014,
-  author       = {Johan De Smedt, Agis Papantoniou},
+  author       = {Johan De Smedt and Agis Papantoniou},
   title        = {The ESCO platform for a collaborative NKOS development},
   year    = {2014},
   venue        = {joint TPDL and JCDL},
@@ -17,7 +17,7 @@
 }
 
 @inproceedings{TPDLLin2014,
-  author       = {Xia Lin, Jae-wook Ahn, Dagobert Soergel},
+  author       = {Xia Lin and Jae-wook Ahn and Dagobert Soergel},
   title        = {Meaningful Concept Displays for KOS Mapping},
   year    = {2014},
   venue        = {joint TPDL and JCDL},
@@ -44,7 +44,7 @@
 }
 
 @inproceedings{TPDLGracy2014,
-  author       = {Karen F. Gracy, Sammy Davidson, Marcia Lei Zeng},
+  author       = {Karen F. Gracy and Sammy Davidson and Marcia Lei Zeng},
   title        = {Semantic Analysis Method (SAM): A Tool for Identifying Potential Access Points in Unstructured Text},
   year    = {2014},
   venue        = {joint TPDL and JCDL},
@@ -53,7 +53,7 @@
 }
 
 @inproceedings{TPDLAlexiev2014,
-  author       = {Vladimir Alexiev, Antoine Isaac, Jutta Lindenthal},
+  author       = {Vladimir Alexiev and Antoine Isaac and Jutta Lindenthal},
   title        = {On Compositionality of ISO 25964 Hierarchical Relationships (BTG, BTP, BTI)},
   year    = {2014},
   venue        = {joint TPDL and JCDL},
@@ -62,7 +62,7 @@
 }
 
 @inproceedings{TPDLDelahousse2014,
-  author       = {Jean Delahousse, Johan De Smedt, Agis Papantoniou},
+  author       = {Jean Delahousse and Johan De Smedt and Agis Papantoniou},
   title        = {PROV-O profile creation for describing and tracking editorial actions on Controlled Vocabularies},
   year    = {2014},
   venue        = {joint TPDL and JCDL},
@@ -71,7 +71,7 @@
 }
 
 @inproceedings{TPDLmayr2014,
-  author       = {Zeljko Carevic , Philipp Mayr},
+  author       = {Zeljko Carevic  and Philipp Mayr},
   title        = {Recommender Systems using Pennant Diagrams in Digital Libraries},
   year    = {2014},
   venue        = {joint TPDL and JCDL},

--- a/TPDL2015.bib
+++ b/TPDL2015.bib
@@ -8,7 +8,7 @@
 }
 
 @inproceedings{TPDLBalakrishnan2015,
-  author       = {Uma Balakrishnan, Jakob Voß},
+  author       = {Uma Balakrishnan and Jakob Voß},
   title        = {The Cocoda Mapping Tool},
   year    = {2015},
   venue        = {Theory and Practice of Digital Libraries},
@@ -17,7 +17,7 @@
 }
 
 @inproceedings{TPDLKempf2015,
-  author       = {Andreas Oskar Kempf, Joachim Neubert},
+  author       = {Andreas Oskar Kempf and Joachim Neubert},
   title        = {The missing link: a terminology mapping effort in economics},
   year    = {2015},
   venue        = {Theory and Practice of Digital Libraries},
@@ -26,7 +26,7 @@
 }
 
 @inproceedings{TPDLTudhope2015,
-  author       = {Douglas Tudhope, Ceri Binding},
+  author       = {Douglas Tudhope and Ceri Binding},
   title        = {Mapping between linked data vocabularies in ARIADNE},
   year    = {2015},
   venue        = {Theory and Practice of Digital Libraries},
@@ -52,7 +52,7 @@
   url = {https://at-web1.comp.glam.ac.uk/pages/research/hypermedia/nkos/nkos2015/content/NKOS2015-abstract-niccolucci.pdf}
 }
 @inproceedings{TPDLShaw2015,
-  author       = {Ryan Shaw, Adam Rabinowitz, Patrick Golden, Eric Kansa},
+  author       = {Ryan Shaw and Adam Rabinowitz and Patrick Golden and Eric Kansa},
   title        = {Report on and demonstration of the PeriodO period gazetteer},
   year    = {2015},
   venue        = {Theory and Practice of Digital Libraries},

--- a/specialissues2001.bib
+++ b/specialissues2001.bib
@@ -8,7 +8,7 @@
 }
 
 @inproceedings{SPTudhope2001,
-  author       = {Douglas Tudhope, Harith Alani and Christopher Jones},
+  author       = {Douglas Tudhope and Harith Alani and Christopher Jones},
   editor       = {Linda Hill and Traugott Koch},
   title        = {Augmenting thesaurus relationships: possibilities for retrieval},
   year    = {2001},

--- a/specialissues2004.bib
+++ b/specialissues2004.bib
@@ -1,5 +1,5 @@
 @inproceedings{SPVizineGoetz2004,
-  author       = {Diane Vizine-Goetz, Carol Hickey, Andrew Houghton and Roger Thompson},
+  author       = {Diane Vizine-Goetz and Carol Hickey and Andrew Houghton and Roger Thompson},
   editor       = {Douglas Tudhope and Traugott Koch},
   title        = {Vocabulary Mapping for Terminology Services},
   year    = {2004},
@@ -18,7 +18,7 @@
 }
 
 @inproceedings{SPSoergel2004,
-  author       = {Dagobert Soergel, Boris Lauser, Anita Liang, Frehiwot Fisseha, Johannes Keizer and Stephen Katz},
+  author       = {Dagobert Soergel and Boris Lauser and Anita Liang and Frehiwot Fisseha and Johannes Keizer and Stephen Katz},
   editor       = {Douglas Tudhope and Traugott Koch},
   title        = {Reengineering Thesauri for New Applications: the AGROVOC Example},
   year = {2004},

--- a/specialissues2006.bib
+++ b/specialissues2006.bib
@@ -1,5 +1,5 @@
 @inproceedings{SPTudhope2006,
-  author       = {Douglas Tudhope, Marianne Lykke Nielsen},
+  author       = {Douglas Tudhope and Marianne Lykke Nielsen},
   title        = {Introduction to Knowledge Organization Systems and Services},
   year    = {2006},
   booktitle = {New Review of Hypermedia and Multimedia},
@@ -17,7 +17,7 @@
 }
 
 @inproceedings{SPNavarretta2006,
-  author       = {Costanza Navarretta, Bolette Sandford Pedersen and Dorte Haltrup Hansen},
+  author       = {Costanza Navarretta and Bolette Sandford Pedersen and Dorte Haltrup Hansen},
   title        = {Language technology in knowledge-organization systems},
   year    = {2006},
   booktitle = {New Review of Hypermedia and Multimedia},

--- a/specialissues2016.bib
+++ b/specialissues2016.bib
@@ -1,5 +1,5 @@
 @inproceedings{SPMayr2016,
-  author       = {Philipp Mayr, Douglas Tudhope, Stella Dextre Clarke, Marcia Lei Zeng, Xia Lin},
+  author       = {Philipp Mayr and Douglas Tudhope and Stella Dextre Clarke and Marcia Lei Zeng and Xia Lin},
   title        = {Recent applications of Knowledge Organization Systems: introduction to a special issue},
   year    = {2016},
   booktitle = {International Journal on Digital Libraries},
@@ -7,7 +7,7 @@
 }
 
 @inproceedings{SPBinding2016,
-  author       = {Ceri Binding, Douglas Tudhope},
+  author       = {Ceri Binding and Douglas Tudhope},
   title        = {Improving interoperability using vocabulary linked data},
   year    = {2016},
   booktitle = {International Journal on Digital Libraries},
@@ -15,7 +15,7 @@
 }
 
 @inproceedings{SPChen2016,
-  author       = {Shu-jiun Chen, Marcia Lei Zeng, Hsueh-hua Chen},
+  author       = {Shu-jiun Chen and Marcia Lei Zeng and Hsueh-hua Chen},
   title        = {Alignment of conceptual structures in controlled vocabularies in the domain of Chinese art: a discussion of issues and patterns},
   year    = {2016},
   booktitle = {International Journal on Digital Libraries},
@@ -23,7 +23,7 @@
 }
 
 @inproceedings{SPAlexiev2016,
-  author       = {Vladimir Alexiev, Antoine Isaac, Jutta Lindenthal},
+  author       = {Vladimir Alexiev and Antoine Isaac and Jutta Lindenthal},
   title        = {On the composition of ISO 25964 hierarchical relations (BTG, BTP, BTI)},
   year    = {2016},
   booktitle = {International Journal on Digital Libraries},
@@ -31,7 +31,7 @@
 }
 
 @inproceedings{SPShaw2016,
-  author       = {Ryan Shaw, Adam Rabinowitz, Patrick Golden, Eric Kansa},
+  author       = {Ryan Shaw and Adam Rabinowitz and Patrick Golden and Eric Kansa},
   title        = {A sharing-oriented design strategy for networked knowledge organization systems},
   year    = {2016},
   booktitle = {International Journal on Digital Libraries},
@@ -39,7 +39,7 @@
 }
 
 @inproceedings{SPNiccolucci2016,
-  author       = {Franco Niccolucci, Sorin Hermon},
+  author       = {Franco Niccolucci and Sorin Hermon},
   title        = {Representing gazetteers and period thesauri in four-dimensional space-time},
   year    = {2016},
   booktitle = {International Journal on Digital Libraries},
@@ -47,7 +47,7 @@
 }
 
 @inproceedings{SPRonzino2016,
-  author       = {Paola Ronzino, Franco Niccolucci, Achille Felicetti, Martin Doerr},
+  author       = {Paola Ronzino and Franco Niccolucci and Achille Felicetti and Martin Doerr},
   title        = {CRMba a CRM extension for the documentation of standing buildings},
   year    = {2016},
   booktitle = {International Journal on Digital Libraries},


### PR DESCRIPTION
Authors should either be listed surname, given, surname, given... or
given surname and given surname... Otherwise fields such as

```
author = {Douglas Tudhope, Marianne Lykke Nielsen}
```

could be read as one person with two given names and three surnames.
